### PR TITLE
New SPFx Property - Sensitivity Label Override

### DIFF
--- a/spfx/src/webparts/siteAdmin/SiteAdminWebPart.manifest.json
+++ b/spfx/src/webparts/siteAdmin/SiteAdminWebPart.manifest.json
@@ -32,6 +32,7 @@
       "officeFabricIconFontName": "AdminSLogoInverse32",
       "properties": {
         "AppTitle": "Site Admin Tool",
+        "DisableSensitivityLabelOverride": false,
         "MaxStorage": 25,
         "MaxStorageDescription": "The max threshold has been met.",
         "ReportsDocSearchFileExt": "csv doc docx dot dotx pdf pot potx pps ppsx ppt pptx txt xls xlsx xlt xltx",

--- a/spfx/src/webparts/siteAdmin/SiteAdminWebPart.ts
+++ b/spfx/src/webparts/siteAdmin/SiteAdminWebPart.ts
@@ -10,6 +10,7 @@ import * as strings from 'SiteAdminWebPartStrings';
 
 export interface ISiteAdminWebPartProps {
   AppTitle: string;
+  DisableSensitivityLabelOverride: boolean;
   MaxStorage: number;
   MaxStorageDescription: string;
   ReportsDocSearchFileExt: string;
@@ -93,6 +94,7 @@ declare const SiteAdmin: {
     context?: WebPartContext;
     el: HTMLElement;
     title?: string;
+    disableSensitivityLabelOverride?: boolean;
     maxStorageDesc?: string;
     maxStorageSize?: number;
     reportProps?: {
@@ -173,6 +175,7 @@ export default class SiteAdminWebPart extends BaseClientSideWebPart<ISiteAdminWe
     SiteAdmin.render({
       context: this.context,
       el: this.domElement,
+      disableSensitivityLabelOverride: this.properties.DisableSensitivityLabelOverride,
       maxStorageDesc: this.properties.MaxStorageDescription,
       maxStorageSize: this.properties.MaxStorage,
       reportProps: {
@@ -312,6 +315,17 @@ export default class SiteAdminWebPart extends BaseClientSideWebPart<ISiteAdminWe
                   label: strings.AppTitle,
                   description: "The title displayed.",
                   value: this.properties.AppTitle
+                })
+              ]
+            },
+            {
+              groupName: "Sensitivity Labels",
+              groupFields: [
+                PropertyPaneToggle("DisableSensitivityLabelOverride", {
+                  label: "Disable Sensivitity Label Override:",
+                  checked: this.properties.DisableSensitivityLabelOverride,
+                  onText: "The admins will only be allowed to apply sensitivity labels to files that haven't been labeled.",
+                  offText: "The admins will be allowed to attempt to override sensitivity labels."
                 })
               ]
             },

--- a/spfx/src/webparts/siteAdmin/SiteAdminWebPart.ts
+++ b/spfx/src/webparts/siteAdmin/SiteAdminWebPart.ts
@@ -420,9 +420,14 @@ export default class SiteAdminWebPart extends BaseClientSideWebPart<ISiteAdminWe
                   text: "Request an Enhancement",
                   target: "_blank"
                 }),
-                PropertyPaneLink('supportLink', {
+                PropertyPaneLink('reportIssue', {
                   href: "https://github.com/microsoft/site-admin/issues",
                   text: "Submit an Issue",
+                  target: "_blank"
+                }),
+                PropertyPaneLink('discussions', {
+                  href: "https://github.com/microsoft/site-admin/discussions",
+                  text: "Ask a Question",
                   target: "_blank"
                 }),
                 PropertyPaneLink('sourceLink', {

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,6 +18,7 @@ export interface IProp {
 }
 export interface IAppProps {
     context?: any;
+    disableSensitivityLabelOverride?: boolean;
     el: HTMLElement;
     maxStorageDesc?: string;
     maxStorageSize?: number;

--- a/src/reports/lists.ts
+++ b/src/reports/lists.ts
@@ -32,6 +32,7 @@ const CSVSensitivityLabelResponseFields = [
 ]
 
 export class Lists {
+    private static _disableLabelOverride: boolean = null;
     private static _items: IList[] = [];
 
     // List Template Types
@@ -204,11 +205,14 @@ export class Lists {
     }
 
     // Runs the report
-    static run(el: HTMLElement, values: { [key: string]: string }, onClose: () => void) {
+    static run(el: HTMLElement, values: { [key: string]: string }, disableLabelOverride: boolean, onClose: () => void) {
         // Show a loading dialog
         LoadingDialog.setHeader("Searching Lists");
         LoadingDialog.setBody("Searching the site...");
         LoadingDialog.show();
+
+        // Set the flag
+        this._disableLabelOverride = disableLabelOverride;
 
         // Clear the items
         this._items = [];
@@ -394,6 +398,7 @@ export class Lists {
                     name: "OverrideLabel",
                     label: "Override Label?",
                     description: "If a label already exists, it will attempt to override it.",
+                    isDisabled: this._disableLabelOverride,
                     type: Components.FormControlTypes.Switch,
                     value: false
                 },

--- a/src/tabs/index.ts
+++ b/src/tabs/index.ts
@@ -79,7 +79,7 @@ export class Tabs {
                 tabName: "Audit Tools",
                 onRender: (el) => {
                     // Render the tab
-                    this._tabReports = new ReportsTab(el, appProps.reportProps, appProps.searchProps);
+                    this._tabReports = new ReportsTab(el, appProps);
                 }
             }
         ];

--- a/src/tabs/reports.ts
+++ b/src/tabs/reports.ts
@@ -1,5 +1,6 @@
 import { Components } from "gd-sprest-bs";
 import { DataSource } from "../ds";
+import { IAppProps } from "../app";
 import * as Reports from "../reports";
 import { ISearchProps } from "./searchProp";
 
@@ -29,14 +30,16 @@ enum ReportTypes {
  */
 export class ReportsTab {
     private _el: HTMLElement = null;
+    private _disableSensitivityLabelOverride: boolean = null;
     private _reportProps: IReportProps = null;
     private _searchProps: ISearchProps = null;
 
     // Constructor
-    constructor(el: HTMLElement, reportProps: IReportProps, searchProps: ISearchProps) {
+    constructor(el: HTMLElement, appProps: IAppProps) {
         this._el = el;
-        this._reportProps = reportProps;
-        this._searchProps = searchProps;
+        this._disableSensitivityLabelOverride = appProps.disableSensitivityLabelOverride;
+        this._reportProps = appProps.reportProps;
+        this._searchProps = appProps.searchProps;
 
         // Render the tab
         this.render();
@@ -196,7 +199,7 @@ export class ReportsTab {
                         });
                         break;
                     case ReportTypes.Lists:
-                        Reports.Lists.run(this._el, form.getValues(), () => {
+                        Reports.Lists.run(this._el, form.getValues(), this._disableSensitivityLabelOverride, () => {
                             // Render this component
                             this.render(selectedReport);
                         });


### PR DESCRIPTION
Adds a new SPFx property to enable/disable the ability to override files that haven't been tagged.