### PR TITLE
Fixed Search Property Function App Update

### DIFF
--- a/src/tabs/searchProp.ts
+++ b/src/tabs/searchProp.ts
@@ -1,6 +1,5 @@
 import { Components } from "gd-sprest-bs";
-import { DataSource } from "../ds";
-import { IProp } from "../app";
+import { DataSource, RequestTypes } from "../ds";
 import { IChangeRequest } from "./changes";
 
 export interface ISearchProps {
@@ -104,7 +103,7 @@ export class SearchPropTab {
                     newValue: this._newValue,
                     scope: "Search",
                     request: {
-                        key: "SearchProperty",
+                        key: RequestTypes.SearchProperty,
                         message: `The request set the site property to '${this._newValue}', will be processed within 5 minutes.`,
                         value: this._newValue
                     },


### PR DESCRIPTION
Set the correct request type to send to the function app. This is why the search property wasn't being updated.