### PR TITLE
Audit Tools - Target Web Dropdown

### DIFF
--- a/spfx/config/package-solution.json
+++ b/spfx/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "site-admin-tool",
     "id": "9c7bcdac-024d-4ffe-b63a-cef526bc1930",
-    "version": "0.9.7.8",
+    "version": "0.9.7.9",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false,

--- a/src/reports/dlp.ts
+++ b/src/reports/dlp.ts
@@ -383,11 +383,14 @@ export class DLP {
         // Hide the loading dialog
         LoadingDialog.hide();
 
+        // Determine the webs to target
+        let siteItems: Components.IDropdownItem[] = values["TargetWeb"] && values["TargetWeb"]["value"] ? [values["TargetWeb"]] as any : DataSource.SiteItems;
+
         // Parse the webs
         let counter = 0;
-        Helper.Executor(DataSource.SiteItems, siteItem => {
+        Helper.Executor(siteItems, siteItem => {
             // Update the status
-            this._elSubNav.children[0].innerHTML = `Searching Site ${++counter} of ${DataSource.SiteItems.length}`;
+            this._elSubNav.children[0].innerHTML = `Searching Site ${++counter} of ${siteItems.length}`;
 
             // Return a promise
             return new Promise(resolve => {

--- a/src/reports/externalUsers.ts
+++ b/src/reports/externalUsers.ts
@@ -399,6 +399,8 @@ export class ExternalUsers {
 
     // Runs the report
     static run(el: HTMLElement, auditOnly: boolean, values: { [key: string]: string }, onClose: () => void) {
+        let users: IUserInfo[] = [];
+
         // Show a loading dialog
         LoadingDialog.setHeader("Loading Security Groups");
         LoadingDialog.setBody("Loading the permissions for this site...");
@@ -406,8 +408,6 @@ export class ExternalUsers {
 
         // Clear the items
         this._items = [];
-
-        let users: IUserInfo[] = [];
 
         // Load the group information
         Web(DataSource.SiteContext.SiteFullUrl, { requestDigest: DataSource.SiteContext.FormDigestValue }).query({

--- a/src/reports/permissions.ts
+++ b/src/reports/permissions.ts
@@ -650,11 +650,14 @@ export class Permissions {
         this._items = [];
         this._roleMapper = {};
 
+        // Determine the webs to target
+        let siteItems: Components.IDropdownItem[] = values["TargetWeb"] && values["TargetWeb"]["value"] ? [values["TargetWeb"]] as any : DataSource.SiteItems;
+
         // Parse all webs
         let counter = 0;
-        Helper.Executor(DataSource.SiteItems, siteItem => {
+        Helper.Executor(siteItems, siteItem => {
             // Update the loading dialog
-            LoadingDialog.setBody(`Getting the roles for web ${++counter} of ${DataSource.SiteItems.length}...`);
+            LoadingDialog.setBody(`Getting the roles for web ${++counter} of ${siteItems.length}...`);
 
             // See if this is a sub-web and doesn't have unique role assignments
             // The sub-webs have the data property set for them
@@ -669,7 +672,7 @@ export class Permissions {
                     ]
                 }).execute(roles => {
                     // Update the loading dialog
-                    LoadingDialog.setBody(`Analyzing the roles for web ${counter} of ${DataSource.SiteItems.length}...`);
+                    LoadingDialog.setBody(`Analyzing the roles for web ${counter} of ${siteItems.length}...`);
 
                     // Analyze the roles
                     this.analyzeRoles(roles.results, siteItem.text, siteItem.data ? siteItem.data.Title : DataSource.Site.RootWeb.Title).then(resolve);

--- a/src/reports/searchEEEU.ts
+++ b/src/reports/searchEEEU.ts
@@ -634,11 +634,14 @@ export class SearchEEEU {
         // See if we are showing hidden lists
         let searchLists = values["SearchLists"];
 
+        // Determine the webs to target
+        let siteItems: Components.IDropdownItem[] = values["TargetWeb"] && values["TargetWeb"]["value"] ? [values["TargetWeb"]] as any : DataSource.SiteItems;
+
         // Parse all webs
         let counter = 0;
-        Helper.Executor(DataSource.SiteItems, siteItem => {
+        Helper.Executor(siteItems, siteItem => {
             // Update the loading dialog
-            LoadingDialog.setBody(`Getting the info for web ${++counter} of ${DataSource.SiteItems.length}...`);
+            LoadingDialog.setBody(`Getting the info for web ${++counter} of ${siteItems.length}...`);
 
             // Return a promise
             return new Promise(resolve => {
@@ -650,7 +653,7 @@ export class SearchEEEU {
                     ]
                 }).execute(web => {
                     // Update the loading dialog
-                    LoadingDialog.setBody(`Analyzing web ${counter} of ${DataSource.SiteItems.length}...`);
+                    LoadingDialog.setBody(`Analyzing web ${counter} of ${siteItems.length}...`);
 
                     // Analyze the site
                     this.analyzeSite(web, searchLists).then(resolve);

--- a/src/reports/searchUsers.ts
+++ b/src/reports/searchUsers.ts
@@ -618,11 +618,14 @@ export class SearchUsers {
         let userName: string = values["UserName"].trim();
         let user: Types.SP.User = values["PeoplePicker"][0];
 
+        // Determine the webs to target
+        let siteItems: Components.IDropdownItem[] = values["TargetWeb"] && values["TargetWeb"]["value"] ? [values["TargetWeb"]] as any : DataSource.SiteItems;
+
         // Parse all webs
         let counter = 0;
-        Helper.Executor(DataSource.SiteItems, siteItem => {
+        Helper.Executor(siteItems, siteItem => {
             // Update the loading dialog
-            LoadingDialog.setBody(`Getting the info for web ${++counter} of ${DataSource.SiteItems.length}...`);
+            LoadingDialog.setBody(`Getting the info for web ${++counter} of ${siteItems.length}...`);
 
             // Return a promise
             return new Promise(resolve => {
@@ -634,7 +637,7 @@ export class SearchUsers {
                     ]
                 }).execute(web => {
                     // Update the loading dialog
-                    LoadingDialog.setBody(`Analyzing web ${counter} of ${DataSource.SiteItems.length}...`);
+                    LoadingDialog.setBody(`Analyzing web ${counter} of ${siteItems.length}...`);
 
                     // Analyze the site
                     this.analyzeSite(web, userName || user).then(resolve);

--- a/src/reports/sensitivityLabels.ts
+++ b/src/reports/sensitivityLabels.ts
@@ -371,11 +371,14 @@ export class SensitivityLabels {
         LoadingDialog.setBody("Loading the libraries...");
         LoadingDialog.show();
 
+        // Determine the webs to target
+        let siteItems: Components.IDropdownItem[] = values["TargetWeb"] && values["TargetWeb"]["value"] ? [values["TargetWeb"]] as any : DataSource.SiteItems;
+
         // Parse the webs
         let counter = 0;
-        Helper.Executor(DataSource.SiteItems, siteItem => {
+        Helper.Executor(siteItems, siteItem => {
             // Update the dialog
-            LoadingDialog.setHeader(`Searching Site ${++counter} of ${DataSource.SiteItems.length}`);
+            LoadingDialog.setHeader(`Searching Site ${++counter} of ${siteItems.length}`);
 
             // Return a promise
             return new Promise(resolve => {

--- a/src/reports/uniquePermissions.ts
+++ b/src/reports/uniquePermissions.ts
@@ -300,11 +300,14 @@ export class UniquePermissions {
         // Clear the items
         this._items = [];
 
+        // Determine the webs to target
+        let siteItems: Components.IDropdownItem[] = values["TargetWeb"] && values["TargetWeb"]["value"] ? [values["TargetWeb"]] as any : DataSource.SiteItems;
+
         // Parse all the webs
         let counter = 0;
-        Helper.Executor(DataSource.SiteItems, siteItem => {
+        Helper.Executor(siteItems, siteItem => {
             // Update the loading dialog
-            LoadingDialog.setHeader(`Site ${++counter} of ${DataSource.SiteItems.length}`);
+            LoadingDialog.setHeader(`Site ${++counter} of ${siteItems.length}`);
 
             // Return a promise
             return new Promise(resolve => {

--- a/src/tabs/index.ts
+++ b/src/tabs/index.ts
@@ -46,8 +46,9 @@ export class Tabs {
 
     // Event when the webs are loaded
     onWebsLoaded(webs: Components.IDropdownItem[]) {
-        // Update the list tab
+        // Update the tabs
         this._tabLists.setWebs(webs);
+        this._tabReports.setWebs(webs);
     }
 
     // Renders the tabs


### PR DESCRIPTION
Updated the audit tools tab to have a sub-web dropdown to run reports against a single web vs the site collection.