### PR TITLE
M365 Group Member/Owners Not Returning All Results

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "datatables.net": "^2.3.2",
     "datatables.net-bs5": "^2.3.2",
     "dattatable": "^2.11.67",
-    "gd-sprest-bs": "^10.15.68",
+    "gd-sprest-bs": "^10.15.69",
     "jquery": "^3.7.1",
     "moment": "^2.30.1"
   },

--- a/spfx/config/package-solution.json
+++ b/spfx/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "site-admin-tool",
     "id": "9c7bcdac-024d-4ffe-b63a-cef526bc1930",
-    "version": "0.9.8.6",
+    "version": "0.9.8.7",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false,

--- a/src/reports/permissions.ts
+++ b/src/reports/permissions.ts
@@ -57,23 +57,56 @@ export class Permissions {
                     if (this._groupIds[groupId] || this._groupIdErrors.indexOf(groupId) >= 0) { resolve(null); return; }
 
                     // Get the group information
-                    DirectorySession().group(groupId).query({
-                        Expand: ["members", "owners"],
-                        Select: [
-                            "calendarUrl", "displayName", "id", "isPublic", "mail",
-                            "members/principalName", "members/id", "members/displayName", "members/mail",
-                            "owners/principalName", "owners/id", "owners/displayName", "owners/mail"
-                        ]
-                    }).execute(group => {
-                        // Add the group information to the mapper
-                        this._groupIds[group.id] = group;
+                    let ds = DirectorySession().group(groupId);
 
-                        // Try the next group
-                        resolve(null);
-                    }, () => {
-                        // Append the error
-                        this._groupIdErrors.push(groupId);
+                    // Get the group information
+                    ds.query({
+                        Select: ["calendarUrl", "displayName", "id", "isPublic", "mail"]
+                    }).batch(group => {
+                        // Ensure the group was found
+                        if (group?.id) {
+                            // Save the group information
+                            this._groupIds[groupId] = group;
+                        } else {
+                            // Append the error
+                            this._groupIdErrors.push(groupId);
+                        }
+                    });
 
+                    // Get the members
+                    ds.members().query({
+                        GetAllItems: true,
+                        Top: 5000,
+                        Select: ["principalName", "id", "displayName", "mail"]
+                    }).batch(members => {
+                        // Ensure members were found
+                        if (members.results?.length >= 0) {
+                            // Add the group information to the mapper
+                            this._groupIds[groupId].members = members as any;
+                        } else {
+                            // Append the error
+                            this._groupIdErrors.push(groupId);
+                        }
+                    });
+
+                    // Get the owners
+                    ds.owners().query({
+                        GetAllItems: true,
+                        Top: 5000,
+                        Select: ["principalName", "id", "displayName", "mail"]
+                    }).batch(owners => {
+                        // Ensure members were found
+                        if (owners.results?.length >= 0) {
+                            // Add the group information to the mapper
+                            this._groupIds[groupId].owners = owners as any;
+                        } else {
+                            // Append the error
+                            this._groupIdErrors.push(groupId);
+                        }
+                    });
+
+                    // Execute the request
+                    ds.execute(() => {
                         // Try the next group
                         resolve(null);
                     });

--- a/src/reports/permissions.ts
+++ b/src/reports/permissions.ts
@@ -58,8 +58,6 @@ export class Permissions {
 
                     // Get the group information
                     let ds = DirectorySession().group(groupId);
-
-                    // Get the group information
                     ds.query({
                         Select: ["calendarUrl", "displayName", "id", "isPublic", "mail"]
                     }).batch(group => {

--- a/src/reports/searchUsers.ts
+++ b/src/reports/searchUsers.ts
@@ -14,6 +14,7 @@ interface ISearchItem {
     GroupInfo?: string;
     Id?: number;
     IsM365Group?: boolean;
+    M365GroupUrl?: string;
     WebTitle: string;
     WebUrl: string;
 }
@@ -122,23 +123,31 @@ export class SearchUsers {
                     // Return a promise
                     return new Promise(resolve => {
                         let groupInfo = groupId.split('_');
+                        let groupName: string = null;
+                        let groupUrl: string = null;
                         let isOwner = groupInfo.length > 1;
 
                         // Get the group information
-                        DirectorySession().group(groupInfo[0]).query({
-                            Expand: ["members", "owners"],
-                            Select: [
-                                "displayName", "id",
-                                "members/principalName", "members/id", "members/displayName", "members/mail",
-                                "owners/principalName", "owners/id", "owners/displayName", "owners/mail"
-                            ]
-                        }).execute(group => {
+                        let ds = DirectorySession().group(groupInfo[0]);
+                        ds.query({
+                            Select: ["calendarUrl", "displayName", "id"]
+                        }).batch(group => {
+                            // Set the group name
+                            groupName = group.displayName;
+                            groupUrl = group.calendarUrl.replace("calendar/group", "groups") + "/members";
+                        });
+
+                        // Get the owners/members for the group
+                        (isOwner ? ds.owners() : ds.members()).query({
+                            GetAllItems: true,
+                            Top: 5000,
+                            Select: ["principalName", "id", "displayName", "mail"]
+                        }).batch(users => {
                             let role = groups[groupId];
 
                             // Parse the users
-                            let users = isOwner ? group.owners.results : group.members.results;
-                            for (let i = 0; i < users.length; i++) {
-                                let user = users[i];
+                            for (let i = 0; i < users?.results.length; i++) {
+                                let user = users.results[i];
 
                                 // See if we are searching by string
                                 if (typeof (search) === "string") {
@@ -148,14 +157,15 @@ export class SearchUsers {
                                         let userItem = {
                                             WebUrl: web.Url,
                                             WebTitle: web.Title,
-                                            Id: userInfo.Id,
-                                            LoginName: userInfo.Name,
-                                            Name: userInfo.Title || userInfo.Name,
-                                            Email: userInfo.EMail,
+                                            Id: user.id,
+                                            LoginName: user.mail,
+                                            Name: user.displayName,
+                                            Email: user.mail,
                                             Group: role.Member.Title,
                                             GroupId: role.Member.Id,
-                                            GroupInfo: `${group.displayName} M365 Group ${isOwner ? "owner" : "member"}`,
+                                            GroupInfo: `${groupName} M365 Group ${isOwner ? "owner" : "member"}`,
                                             IsM365Group: true,
+                                            M365GroupUrl: groupUrl,
                                             Role: role.RoleDefinitionBindings.results[0].Name,
                                             RoleInfo: role.RoleDefinitionBindings.results[0].Description || ""
                                         };
@@ -169,14 +179,15 @@ export class SearchUsers {
                                     let userItem = {
                                         WebUrl: web.Url,
                                         WebTitle: web.Title,
-                                        Id: userInfo.Id,
-                                        LoginName: userInfo.Name,
-                                        Name: userInfo.Title || userInfo.Name,
-                                        Email: userInfo.EMail,
+                                        Id: user.id,
+                                        LoginName: user.mail,
+                                        Name: user.displayName,
+                                        Email: user.mail,
                                         Group: role.Member.Title,
                                         GroupId: role.Member.Id,
-                                        GroupInfo: `${group.displayName} M365 Group ${isOwner ? "owner" : "member"}`,
+                                        GroupInfo: `${groupName} M365 Group ${isOwner ? "owner" : "member"}`,
                                         IsM365Group: true,
+                                        M365GroupUrl: groupUrl,
                                         Role: role.RoleDefinitionBindings.results[0].Name,
                                         RoleInfo: role.RoleDefinitionBindings.results[0].Description || ""
                                     };
@@ -184,10 +195,10 @@ export class SearchUsers {
                                     this._dashboard.Datatable.addRow(userItem);
                                 }
                             }
+                        });
 
-                            // Try the next group
-                            resolve(null);
-                        }, () => {
+                        // Execute the request
+                        ds.execute(() => {
                             // Try the next group
                             resolve(null);
                         });


### PR DESCRIPTION
Updated the logic for the permissions report to get the members and owners separately to ensure all users are returned.

Updated the search users report to clearly identify the member/owner of a M365 group, and not the site group.