### PR TITLE
DLP Report - Permissions & Actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "dependencies": {
     "datatables.net": "^2.3.2",
     "datatables.net-bs5": "^2.3.2",
-    "dattatable": "^2.11.70",
-    "gd-sprest-bs": "^10.15.69",
+    "dattatable": "^2.11.71",
+    "gd-sprest-bs": "^10.15.70",
     "jquery": "^3.7.1",
     "moment": "^2.30.1"
   },

--- a/spfx/src/webparts/siteAdmin/SiteAdminWebPart.ts
+++ b/spfx/src/webparts/siteAdmin/SiteAdminWebPart.ts
@@ -66,6 +66,7 @@ export interface ISiteAdminWebPartProps {
   MaxStorageDescription: string;
   ReportsDocRententionYears: string;
   ReportsDLPFileExt: string;
+  ReportsDLPGroups: string;
   ReportsDocSearchFileExt: string;
   ReportsDocSearchKeywords: string;
   SensitivityLabelFileExt: string;
@@ -198,6 +199,7 @@ declare const SiteAdmin: {
     reportProps?: {
       docRententionYears?: string;
       dlpFileExt?: string;
+      dlpGroups?: string[];
       docSearchFileExt?: string;
       docSearchKeywords?: string;
       sensitivityLabelFileExt?: string;
@@ -328,6 +330,7 @@ export default class SiteAdminWebPart extends BaseClientSideWebPart<ISiteAdminWe
       maxStorageSize,
       reportProps: {
         dlpFileExt: this.properties.ReportsDLPFileExt,
+        dlpGroups: (this.properties.ReportsDLPGroups || "").split(",").map(group => group.trim()),
         docRententionYears: this.properties.ReportsDocRententionYears,
         docSearchFileExt: this.properties.ReportsDocSearchFileExt,
         docSearchKeywords: this.properties.ReportsDocSearchKeywords,
@@ -650,7 +653,16 @@ export default class SiteAdminWebPart extends BaseClientSideWebPart<ISiteAdminWe
                 PropertyPaneTextField("ReportsDLPFileExt", {
                   label: strings.ReportsDLPFileExt,
                   description: "The default file extensions to search.",
+                  multiline: true,
+                  rows: 6,
                   value: this.properties.ReportsDLPFileExt
+                }),
+                PropertyPaneTextField("ReportsDLPGroups", {
+                  label: strings.ReportsDLPGroups,
+                  description: "A CSV formatted string containing the group names to indicate a file being overshared. Do not include Everyone or EEEU, as they are the default groups to indicate oversharing.",
+                  multiline: true,
+                  rows: 6,
+                  value: this.properties.ReportsDLPGroups
                 }),
                 PropertyPaneDropdown("ReportsDocRententionYears", {
                   label: strings.ReportsDocRententionYears,
@@ -673,11 +685,15 @@ export default class SiteAdminWebPart extends BaseClientSideWebPart<ISiteAdminWe
                 PropertyPaneTextField("ReportsDocSearchFileExt", {
                   label: strings.ReportsDocSearchFileExt,
                   description: "The default file extensions to search.",
+                  multiline: true,
+                  rows: 6,
                   value: this.properties.ReportsDocSearchFileExt
                 }),
                 PropertyPaneTextField("ReportsDocSearchKeywords", {
                   label: strings.ReportsDocSearchKeywords,
                   description: "The default keywords to search for.",
+                  multiline: true,
+                  rows: 6,
                   value: this.properties.ReportsDocSearchKeywords
                 }),
               ]

--- a/spfx/src/webparts/siteAdmin/SiteAdminWebPart.ts
+++ b/spfx/src/webparts/siteAdmin/SiteAdminWebPart.ts
@@ -508,6 +508,19 @@ export default class SiteAdminWebPart extends BaseClientSideWebPart<ISiteAdminWe
                   onText: "The option to run reports against the user's OneDrive will be hidden.",
                   offText: "The option to run reports against the user's OneDrive will be visible."
                 }),
+                PropertyPaneToggle("SiteAttestation", {
+                  label: "Site Attestation Feature",
+                  checked: this.properties.SiteAttestation,
+                  onText: "The admins will be able to record the date/time of attestation.",
+                  offText: "This feature will not be visible in the solution."
+                }),
+                PropertyPaneTextField("SiteAttestationText", {
+                  label: "Site Attestation Text",
+                  description: "The text displayed in the confirmation dialog.",
+                  multiline: true,
+                  rows: 6,
+                  value: this.properties.SiteAttestationText
+                }),
                 PropertyPaneDropdown("MaxBatchSize", {
                   label: strings.MaxBatchSize,
                   selectedKey: this.properties.MaxBatchSize,
@@ -538,19 +551,6 @@ export default class SiteAdminWebPart extends BaseClientSideWebPart<ISiteAdminWe
                     { key: 9, text: "9" },
                     { key: 10, text: "10" }
                   ]
-                }),
-                PropertyPaneToggle("SiteAttestation", {
-                  label: "Site Attestation Feature",
-                  checked: this.properties.SiteAttestation,
-                  onText: "The admins will be able to record the date/time of attestation.",
-                  offText: "This feature will not be visible in the solution."
-                }),
-                PropertyPaneTextField("SiteAttestationText", {
-                  label: "Site Attestation Text",
-                  description: "The text displayed in the confirmation dialog.",
-                  multiline: true,
-                  rows: 6,
-                  value: this.properties.SiteAttestationText
                 })
               ]
             },

--- a/spfx/src/webparts/siteAdmin/loc/en-us.js
+++ b/spfx/src/webparts/siteAdmin/loc/en-us.js
@@ -6,6 +6,7 @@ define([], function () {
     "MaxStorage": "Max Storage Allowed",
     "MaxStorageDescription": "Max Storage Description",
     "ReportsDLPFileExt": "DLP Default File Extensions",
+    "ReportsDLPGroups": "DLP Oversharing Groups",
     "ReportsDocRententionYears": "Document Retention Default Years",
     "ReportsDocSearchFileExt": "Document Search Default File Extensions",
     "ReportsDocSearchKeywords": "Document Search Default Keywords",

--- a/spfx/src/webparts/siteAdmin/loc/mystrings.d.ts
+++ b/spfx/src/webparts/siteAdmin/loc/mystrings.d.ts
@@ -5,6 +5,7 @@ declare interface ISiteAdminWebPartStrings {
   MaxStorage: string;
   MaxStorageDescription: string;
   ReportsDLPFileExt: string;
+  ReportsDLPGroups: string;
   ReportsDocRententionYears: string;
   ReportsDocSearchFileExt: string;
   ReportsDocSearchKeywords: string;

--- a/src/ds.ts
+++ b/src/ds.ts
@@ -3,6 +3,7 @@ import {
     Components, ContextInfo, DirectorySession, GroupSiteManager, Helper,
     Search, SensitivityLabels, Site, SPTypes, Types, Web, v2
 } from "gd-sprest-bs";
+import { M365Groups } from "./m365Groups";
 import { Security } from "./security";
 import Strings from "./strings";
 
@@ -147,6 +148,7 @@ export class DataSource {
                 Expand: ["Users"]
             }).execute(ownersGroup => {
                 let groupIds = [];
+                let groupIdMapper = {};
 
                 // Parse the group users
                 for (let i = 0; i < ownersGroup.Users.results.length; i++) {
@@ -164,54 +166,49 @@ export class DataSource {
                     // Else, see if this is a M365 group
                     else if (item.PrincipalType == SPTypes.PrincipalTypes.SecurityGroup) {
                         // Add the group id
-                        groupIds.push(this.getGroupId(item.LoginName));
+                        let groupId = M365Groups.getGroupId(item.LoginName);
+                        if (groupId) {
+                            groupIds.push(groupId);
+                            groupIdMapper[groupId] = item.LoginName;
+                        }
                     }
                 }
 
-                // Create the request for getting the M365 group information in a batch request
-                let ds = DirectorySession();
-
-                // Parse the group ids to see if the user is a site admin
+                // Load the group information
                 let isSiteAdmin = false;
-                groupIds.forEach(groupId => {
-                    // See if the user is an member/owner of this group
-                    ds.group(groupId).query({
-                        Expand: ["members", "owners"],
-                        Select: [
-                            "id",
-                            "members/principalName", "members/id", "members/displayName", "members/mail",
-                            "owners/principalName", "owners/id", "owners/displayName", "owners/mail"
-                        ]
-                    }).batch(group => {
-                        // See if we already set the flag
-                        if (isSiteAdmin) { return; }
+                M365Groups.getGroupInfo(groupIds, (group, groupId) => {
+                    // Return if we already set the flag
+                    if (isSiteAdmin) { return; }
 
-                        // See if the user is a member
-                        if (group.members) {
-                            for (let i = 0; i < group.members.results.length; i++) {
-                                if (group.members.results[i].mail == ContextInfo.userEmail) {
-                                    // Set the flag
-                                    isSiteAdmin = true;
-                                    return;
-                                }
+                    // See if this is targeting the owner's group
+                    if (groupIdMapper[groupId].endsWith("_o")) {
+                        // Parse the owners
+                        let owners = group?.owners.results || [];
+                        for (let i = 0; i < owners.length; i++) {
+                            let owner = owners[i];
+
+                            // See if this is the user
+                            if (owner.mail == ContextInfo.userEmail) {
+                                // Set the flag
+                                isSiteAdmin = true;
+                                return;
                             }
                         }
+                    } else {
+                        // Parse the members
+                        let members = group?.members.results || [];
+                        for (let i = 0; i < members.length; i++) {
+                            let member = members[i];
 
-                        // See if the user is a owner
-                        if (group.owners) {
-                            for (let i = 0; i < group.owners.results.length; i++) {
-                                if (group.owners.results[i].mail == ContextInfo.userEmail) {
-                                    // Set the flag
-                                    isSiteAdmin = true;
-                                    return;
-                                }
+                            // See if this is the user
+                            if (member.mail == ContextInfo.userEmail) {
+                                // Set the flag
+                                isSiteAdmin = true;
+                                return;
                             }
                         }
-                    });
-                });
-
-                // Execute the request
-                ds.execute(() => {
+                    }
+                }).then(groups => {
                     // See if the user is an admin
                     if (isSiteAdmin) {
                         // Resolve the request
@@ -275,7 +272,7 @@ export class DataSource {
                         // Else, see if this is a M365 group
                         else if (item.PrincipalType == SPTypes.PrincipalTypes.SecurityGroup) {
                             // Add the group id
-                            groupIds.push(this.getGroupId(item.LoginName));
+                            groupIds.push(M365Groups.getGroupId(item.LoginName));
                         }
                     }
 
@@ -286,50 +283,36 @@ export class DataSource {
                         return;
                     }
 
-                    // Create the request for getting the M365 group information in a batch request
-                    let ds = DirectorySession();
-
-                    // Parse the group ids to see if the user is a site admin
+                    // Get the group information
                     let isSiteAdmin = false;
-                    groupIds.forEach(groupId => {
-                        // See if the user is an member/owner of this group
-                        ds.group(groupId).query({
-                            Expand: ["members", "owners"],
-                            Select: [
-                                "id",
-                                "members/principalName", "members/id", "members/displayName", "members/mail",
-                                "owners/principalName", "owners/id", "owners/displayName", "owners/mail"
-                            ]
-                        }).batch(group => {
-                            // See if we already set the flag
-                            if (isSiteAdmin) { return; }
+                    M365Groups.getGroupInfo(groupIds, (group, groupId) => {
+                        // See if we already set the flag
+                        if (isSiteAdmin) { return; }
 
-                            // See if the user is a member
-                            if (group.members) {
-                                for (let i = 0; i < group.members.results.length; i++) {
-                                    if (group.members.results[i].mail == ContextInfo.userEmail) {
-                                        // Set the flag
-                                        isSiteAdmin = true;
-                                        return;
-                                    }
+                        // Return if the group didn't load
+                        if (group == null) { return; }
+
+                        // See if we are targeting the owner's group
+                        if (groupId.split('_').length > 0) {
+                            let owners = group.owners?.results || [];
+                            for (let i = 0; i < owners.length; i++) {
+                                if (owners[i].mail == ContextInfo.userEmail) {
+                                    // Set the flag
+                                    isSiteAdmin = true;
+                                    break;
                                 }
                             }
-
-                            // See if the user is a owner
-                            if (group.owners) {
-                                for (let i = 0; i < group.owners.results.length; i++) {
-                                    if (group.owners.results[i].mail == ContextInfo.userEmail) {
-                                        // Set the flag
-                                        isSiteAdmin = true;
-                                        return;
-                                    }
+                        } else {
+                            let members = group.members?.results || [];
+                            for (let i = 0; i < members.length; i++) {
+                                if (members[i].mail == ContextInfo.userEmail) {
+                                    // Set the flag
+                                    isSiteAdmin = true;
+                                    break;
                                 }
                             }
-                        });
-                    });
-
-                    // Execute the request
-                    ds.execute(() => {
+                        }
+                    }).then(() => {
                         // Resolve the request
                         resolve(isSiteAdmin);
                     });
@@ -429,17 +412,6 @@ export class DataSource {
                 resolve(drive?.id);
             }, reject);
         });
-    }
-
-    // Returns the group id from the login name
-    static getGroupId(loginName: string): string {
-        // Get the group id from the login name
-        let userInfo = loginName.split('|');
-        let groupInfo = userInfo[userInfo.length - 1];
-        let groupId = groupInfo.split('_')[0];
-
-        // Ensure it's a guid and return null if it's not
-        return /^[{]?[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}[}]?$/.test(groupId) ? groupId : null;
     }
 
     // List

--- a/src/m365Groups.ts
+++ b/src/m365Groups.ts
@@ -1,0 +1,131 @@
+import { DirectorySession, Helper, Types } from "gd-sprest-bs";
+
+// Return type when calling to get group information
+export interface IM365Result {
+    groups: { [key: string]: Types.SP.Directory.GroupOData };
+    error: { [key: string]: boolean };
+}
+
+/**
+ * M365 Groups
+ * Loads and stores information from M365 groups to reduce redundant calls.
+ */
+export class M365Groups {
+    // Group ids that errored when trying to load the information
+    private static _errorGroupIds: { [key: string]: boolean } = {};
+    static errorLoading(groupId: string): boolean { return this._errorGroupIds[groupId]; }
+
+    // M365 Groups
+    private static _groups: { [key: string]: Types.SP.Directory.GroupOData } = {};
+    static groupById(groupId: string): Types.SP.Directory.GroupOData { return this._groups[groupId]; }
+
+    // Returns the group id from the login name
+    static getGroupId(value: string): string {
+        // Get the group id from the login name
+        let userInfo = value.split('|');
+        let groupInfo = userInfo[userInfo.length - 1];
+        let groupId = groupInfo.split('_')[0];
+
+        // Ensure it's a guid and return null if it's not
+        return /^[{]?[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}[}]?$/.test(groupId) ? groupId : null;
+    }
+
+    // Returns the url to the group
+    static getGroupUrl(group: Types.SP.Directory.GroupOData): string {
+        return group.calendarUrl.replace("calendar/group", "groups") + "/members";
+    }
+
+    // Get the M365 group information
+    static getGroupInfo(groupIds: string[], onGroupLoaded?: (group: Types.SP.Directory.GroupOData, groupId: string) => void): PromiseLike<IM365Result> {
+        // Return a promise
+        return new Promise((resolve) => {
+            let result: IM365Result = { groups: {}, error: {} };
+
+            // Parse the group ids
+            Helper.Executor(groupIds, (groupId) => {
+                // See if we already loaded this group and it errored
+                if (this._errorGroupIds[groupId]) {
+                    result.error[groupId] = true;
+                    return;
+                }
+
+                // See if we already loaded this group
+                if (this._groups[groupId]) {
+                    result.groups[groupId] = this._groups[groupId];
+                    return;
+                }
+
+                // Load the group information
+                this.loadGroupById(groupId).then(group => {
+                    // Save the group information
+                    result.groups[groupId] = group;
+
+                    // Call the event
+                    onGroupLoaded ? onGroupLoaded(group, groupId) : null;
+
+                    // Try the next group
+                    resolve(null);
+                }, () => {
+                    // Add the error
+                    result.error[groupId] = true;
+
+                    // Call the event
+                    onGroupLoaded ? onGroupLoaded(null, groupId) : null;
+
+                    // Try the next group
+                    resolve(null);
+                });
+            });
+        });
+    }
+
+    // Loads the m365 group
+    private static loadGroupById(groupId: string): PromiseLike<Types.SP.Directory.GroupOData> {
+        // Return a promise
+        return new Promise((resolve, reject) => {
+            // Get the group information
+            let ds = DirectorySession().group(groupId);
+            ds.query({
+                Select: ["calendarUrl", "displayName", "id", "isPublic", "mail"]
+            }).execute(group => {
+                // Save the group information
+                this._groups[group.id] = group;
+
+                // Get the group members
+                ds.members().query({
+                    GetAllItems: true,
+                    Top: 5000,
+                    Select: ["principalName", "id", "displayName", "mail"]
+                }).execute(members => {
+                    // Add the group information to the mapper
+                    this._groups[groupId].members = members as any;
+                }, () => {
+                    // Try the next group
+                    resolve(null);
+                });
+
+                // Get the group owners
+                ds.owners().query({
+                    GetAllItems: true,
+                    Top: 5000,
+                    Select: ["principalName", "id", "displayName", "mail"]
+                }).execute(owners => {
+                    // Add the group information to the mapper
+                    this._groups[groupId].owners = owners as any;
+
+                    // Try the next group
+                    resolve(null);
+                }, () => {
+                    // Try the next group
+                    resolve(null);
+                }, true);
+            }, () => {
+                // Error loading this group
+                this._errorGroupIds[groupId] = true;
+
+                // Reject the request
+                reject();
+            });
+        });
+    }
+}

--- a/src/m365Groups.ts
+++ b/src/m365Groups.ts
@@ -55,27 +55,30 @@ export class M365Groups {
                     return;
                 }
 
-                // Load the group information
-                this.loadGroupById(groupId).then(group => {
-                    // Save the group information
-                    result.groups[groupId] = group;
+                // Return a promise
+                return new Promise(resolve => {
+                    // Load the group information
+                    this.loadGroupById(groupId).then(group => {
+                        // Save the group information
+                        result.groups[groupId] = group;
 
-                    // Call the event
-                    onGroupLoaded ? onGroupLoaded(group, groupId) : null;
+                        // Call the event
+                        onGroupLoaded ? onGroupLoaded(group, groupId) : null;
 
-                    // Try the next group
-                    resolve(null);
-                }, () => {
-                    // Add the error
-                    result.error[groupId] = true;
+                        // Try the next group
+                        resolve(null);
+                    }, () => {
+                        // Add the error
+                        result.error[groupId] = true;
 
-                    // Call the event
-                    onGroupLoaded ? onGroupLoaded(null, groupId) : null;
+                        // Call the event
+                        onGroupLoaded ? onGroupLoaded(null, groupId) : null;
 
-                    // Try the next group
-                    resolve(null);
+                        // Try the next group
+                        resolve(null);
+                    });
                 });
-            });
+            }).then(() => { resolve(result); });
         });
     }
 
@@ -90,41 +93,44 @@ export class M365Groups {
             }).execute(group => {
                 // Save the group information
                 this._groups[group.id] = group;
-
-                // Get the group members
-                ds.members().query({
-                    GetAllItems: true,
-                    Top: 5000,
-                    Select: ["principalName", "id", "displayName", "mail"]
-                }).execute(members => {
-                    // Add the group information to the mapper
-                    this._groups[groupId].members = members as any;
-                }, () => {
-                    // Try the next group
-                    resolve(null);
-                });
-
-                // Get the group owners
-                ds.owners().query({
-                    GetAllItems: true,
-                    Top: 5000,
-                    Select: ["principalName", "id", "displayName", "mail"]
-                }).execute(owners => {
-                    // Add the group information to the mapper
-                    this._groups[groupId].owners = owners as any;
-
-                    // Try the next group
-                    resolve(null);
-                }, () => {
-                    // Try the next group
-                    resolve(null);
-                }, true);
             }, () => {
                 // Error loading this group
                 this._errorGroupIds[groupId] = true;
 
                 // Reject the request
                 reject();
+            });
+
+            // Get the group members
+            ds.members().query({
+                GetAllItems: true,
+                Top: 5000,
+                Select: ["principalName", "id", "displayName", "mail"]
+            }).execute(members => {
+                // Add the group information to the mapper
+                this._groups[groupId].members = members as any;
+            }, () => {
+                // Try the next group
+                resolve(null);
+            }, true);
+
+            // Get the group owners
+            ds.owners().query({
+                GetAllItems: true,
+                Top: 5000,
+                Select: ["principalName", "id", "displayName", "mail"]
+            }).execute(owners => {
+                // Add the group information to the mapper
+                this._groups[groupId].owners = owners as any;
+            }, () => {
+                // Try the next group
+                resolve(null);
+            }, true);
+
+            // Wait for the requests to complete
+            ds.done(() => {
+                // Try the next group
+                resolve(this._groups[groupId]);
             });
         });
     }

--- a/src/reports/dlp.ts
+++ b/src/reports/dlp.ts
@@ -222,21 +222,138 @@ export class DLP {
             let role = roles[i];
 
             // See if this is the eeeu or everyone
-            if (role.Member.Title == "Everyone except external users" || role.Member.Title == "Everyone") {
+            if (role.Member.Title == "Everyone except external users" || role.Member.Title == "Everyone" || this._oversharedGroups.indexOf(role.Member.Title) >= 0) {
                 // Set the flag
                 isOvershared = true;
                 break;
             }
             // Else, see if it's one of the custom groups
-            else if (this._oversharedGroups.indexOf(role.Member.Title) >= 0) {
-                // Set the flag
-                isOvershared = true;
-                break;
+            else {
+                // Parse the users
+                let users: Types.SP.User[] = role.Member["Users"] ? role.Member["Users"].results : [];
+                for (let i = 0; i < users.length; i++) {
+                    let user = users[i];
+
+                    // See if this is the eeeu or everyone
+                    if (user.Title == "Everyone except external users" || user.Title == "Everyone" || this._oversharedGroups.indexOf(user.Title) >= 0) {
+                        // Set the flag
+                        isOvershared = true;
+                        break;
+                    }
+                }
+
+                // Break from the loop if the flag is set
+                if (isOvershared) { break; }
             }
         }
 
         // Return the flag
         return isOvershared;
+    }
+
+    // Removes the groups that are flagging the file as overshared
+    private static removeOversharedGroups(item: IDLPItem, onComplete: (permissions: Types.SP.RoleAssignmentOData[]) => void) {
+        // Show a canvas form
+        CanvasForm.clear();
+        CanvasForm.setHeader("Secure Document");
+        CanvasForm.setType(Components.OffcanvasTypes.End);
+        CanvasForm.setSize(Components.OffcanvasSize.Small2);
+
+        // Set the content
+        CanvasForm.setBody(`
+            <p>The file will break inheritance and remove the groups that are flagging this file as overshared. Click on 'Confirm' below to proceed with this action.</p>
+            <div class="d-flex justify-content-end"></div>
+        `);
+
+        Components.ButtonGroup({
+            el: CanvasForm.BodyElement.querySelector("div"),
+            className: "mt-3",
+            buttons: [
+                {
+                    text: "Confirm",
+                    type: Components.ButtonTypes.OutlinePrimary,
+                    onClick: () => {
+                        // Hide the canvas form
+                        CanvasForm.hide();
+
+                        // Show a loading dialog
+                        LoadingDialog.setHeader("Clearing Permissions");
+                        LoadingDialog.setBody("Breaking inheritance for this item...");
+                        LoadingDialog.show();
+
+                        // Set the list containing the item
+                        let list = Web(item.WebUrl, {
+                            disableCache: true,
+                            requestDigest: DataSource.SiteContext.FormDigestValue
+                        }).Lists().getById(item.ListId);
+
+                        // See if we need to break inheritance
+                        if (!item.HasUniquePermissions) {
+                            // Break role inheritance and copy the permissions
+                            list.Items(item.Id).breakRoleInheritance(true, false).execute(() => {
+                                // Update the dialog
+                                LoadingDialog.setBody("Getting the permissions for this item...");
+                            });
+                        }
+
+                        // Get the role assignments for this item
+                        list.Items(item.Id).RoleAssignments().query({ Expand: ["Member/Users"] }).execute(permissions => {
+                            let roles = list.Items(item.Id).RoleAssignments();
+
+                            // Update the dialog
+                            LoadingDialog.setBody("Removing the groups for this...");
+
+                            // Check if any role assignment matches the overshared groups
+                            for (let i = 0; i < permissions.results.length; i++) {
+                                let permission = permissions.results[i];
+
+                                // See if this is the eeeu, everyone or the custom group
+                                if (permission.Member.Title == "Everyone except external users" || permission.Member.Title == "Everyone" || this._oversharedGroups.indexOf(permission.Member.Title) >= 0) {
+                                    // Remove the role assignment
+                                    roles.removeRoleAssignment(permission.PrincipalId).execute(true);
+                                }
+                                // Else, go through the users
+                                else {
+                                    let users: Types.SP.User[] = permission.Member["Users"] ? permission.Member["Users"].results : [];
+                                    users.forEach(user => {
+                                        // See if this is the eeeu or everyone
+                                        if (user.Title == "Everyone except external users" || user.Title == "Everyone" || this._oversharedGroups.indexOf(user.Title) >= 0) {
+                                            // Remove the role assignment
+                                            roles.removeRoleAssignment(permission.PrincipalId).execute(true);
+                                        }
+                                    });
+                                }
+                            }
+
+                            // Wait for the requests to complete
+                            roles.done(() => {
+                                // Load the permissions again for this item
+                                list.Items(item.Id).RoleAssignments().query({
+                                    Expand: ["Member/Users", "RoleDefinitionBindings"]
+                                }).execute(permissions => {
+                                    // Call the complete event
+                                    onComplete(permissions.results);
+
+                                    // Hide the loading dialog
+                                    LoadingDialog.hide();
+                                });
+                            });
+                        }, true);
+                    }
+                },
+                {
+                    text: "Close",
+                    type: Components.ButtonTypes.OutlineSecondary,
+                    onClick: () => {
+                        // Hide the form
+                        CanvasForm.hide();
+                    }
+                }
+            ]
+        });
+
+        // Show the canvas form
+        CanvasForm.show();
     }
 
     // Renders the search summary
@@ -388,7 +505,7 @@ export class DLP {
                         className: "text-end",
                         name: "",
                         title: "",
-                        onRenderCell: (el, col, row: IDLPItem) => {
+                        onRenderCell: (el, col, row: IDLPItem, rowIdx) => {
                             let btnDelete: Components.IButton = null;
 
                             // Set the tooltips
@@ -421,6 +538,34 @@ export class DLP {
                                     }
                                 }
                             ];
+
+                            // See if the file is overshared
+                            if (row.Overshared === "Yes") {
+                                tooltips.push({
+                                    content: "Click to remove the groups that are flagging this file as overshared.",
+                                    btnProps: {
+                                        className: "pe-2 py-1",
+                                        text: "Secure Document",
+                                        type: Components.ButtonTypes.OutlinePrimary,
+                                        onClick: () => {
+                                            // Remove the overshared groups from the permissions
+                                            this.removeOversharedGroups(row, permissions => {
+                                                // Update the permissions for this item
+                                                row.Permissions = permissions;
+
+                                                // Update the overshared status
+                                                row.Overshared = this.isOvershared(permissions) ? "Yes" : "No";
+
+                                                // Set the flag if we are no longer oversharing
+                                                row.HasUniquePermissions = row.Overshared === "Yes" ? row.HasUniquePermissions : true;
+
+                                                // Update this row
+                                                this._dashboard.updateRow(rowIdx, row);
+                                            });
+                                        }
+                                    }
+                                });
+                            }
 
                             // See if the file has broken inheritance
                             if (row.HasUniquePermissions) {

--- a/src/reports/dlp.ts
+++ b/src/reports/dlp.ts
@@ -18,6 +18,7 @@ interface IDLPItem {
     LastProcessedTime: string;
     ListId: string;
     ListTitle: string;
+    Overshared: string;
     Path: string;
     Permissions: Types.SP.RoleAssignmentOData[];
     WebUrl: string;
@@ -51,6 +52,7 @@ export class DLP {
     private static _elSubNav: HTMLElement = null;
     private static _items: IDLPItem[] = [];
     private static _loadOneDrive: boolean = false;
+    private static _oversharedGroups: string[] = [];
     private static _stopFl: boolean = false;
 
     // Gets the form fields to display
@@ -138,6 +140,7 @@ export class DLP {
                                                 LastProcessedTime: result.GetDlpPolicyTip.LastProcessedTime,
                                                 ListId: lib.Id,
                                                 ListTitle: lib.Title,
+                                                Overshared: this.isOvershared(result.RoleAssignments.results as any) ? "Yes" : "No",
                                                 Path: item["FileRef"],
                                                 Permissions: result.RoleAssignments.results as any,
                                                 WebId: webId,
@@ -171,6 +174,62 @@ export class DLP {
                 });
             }).then(resolve);
         });
+    }
+
+    // Returns the groups that are flagging the file as overshared
+    private static getOversharedGroups(roles: Types.SP.RoleAssignmentOData[]): string[] {
+        let groups = [];
+
+        // Check if any role assignment matches the overshared groups
+        for (let i = 0; i < roles.length; i++) {
+            let role = roles[i];
+
+            // See if this is the eeeu, everyone or the custom group
+            if (role.Member.Title == "Everyone except external users" || role.Member.Title == "Everyone" || this._oversharedGroups.indexOf(role.Member.Title) >= 0) {
+                // Append the group
+                groups.push(role.Member.Title);
+            }
+            // Else, go through the users
+            else {
+                let users: Types.SP.User[] = role.Member["Users"] ? role.Member["Users"].results : [];
+                users.forEach(user => {
+                    // See if this is the eeeu or everyone
+                    if (user.Title == "Everyone except external users" || user.Title == "Everyone" || this._oversharedGroups.indexOf(user.Title) >= 0) {
+                        // Append the group
+                        groups.push(role.Member.Title + " - " + user.Title);
+                    }
+                });
+            }
+        }
+
+        // Return the groups
+        return groups;
+    }
+
+    // Determines if a file is overshared
+    private static isOvershared(roles: Types.SP.RoleAssignmentOData[]): boolean {
+        let isOvershared = false;
+
+        // Check if any role assignment matches the overshared groups
+        for (let i = 0; i < roles.length; i++) {
+            let role = roles[i];
+
+            // See if this is the eeeu or everyone
+            if (role.Member.Title == "Everyone except external users" || role.Member.Title == "Everyone") {
+                // Set the flag
+                isOvershared = true;
+                break;
+            }
+            // Else, see if it's one of the custom groups
+            else if (this._oversharedGroups.indexOf(role.Member.Title) >= 0) {
+                // Set the flag
+                isOvershared = true;
+                break;
+            }
+        }
+
+        // Return the flag
+        return isOvershared;
     }
 
     // Renders the search summary
@@ -247,10 +306,34 @@ export class DLP {
                         title: "Condition"
                     },
                     {
-                        name: "LastProcessedTime",
-                        title: "Last Processed Time",
+                        name: "",
+                        title: "Overshared",
                         onRenderCell: (el, col, item: IDLPItem) => {
-                            el.innerHTML = item.LastProcessedTime ? moment(item.LastProcessedTime).format(Strings.TimeFormat) : "";
+                            let isOvershared = item.Overshared === "Yes" ? true : false;
+
+                            // Set the order info
+                            el.setAttribute("data-order", item.Overshared);
+
+                            // Make the badge display in the middle
+                            el.style.verticalAlign = "middle";
+
+                            // Render a badge
+                            let badge = Components.Badge({
+                                el,
+                                className: "me-2",
+                                content: isOvershared ? "Overshared" : item.Overshared,
+                                type: isOvershared ? Components.BadgeTypes.Danger : Components.BadgeTypes.Success,
+                                isPill: true
+                            });
+
+                            // See if this is overshared
+                            if (isOvershared) {
+                                // Render a tooltip
+                                Components.Tooltip({
+                                    target: badge.el,
+                                    content: `The file has been flagged as overshared because it's shared with the following groups:<br/>${this.getOversharedGroups(item.Permissions).join("<br/>")}`
+                                });
+                            }
                         }
                     },
                     {
@@ -387,9 +470,10 @@ export class DLP {
     }
 
     // Runs the report
-    static run(el: HTMLElement, auditOnly: boolean, values: { [key: string]: string }, onClose: () => void) {
+    static run(el: HTMLElement, auditOnly: boolean, oversharedGroups: string[], values: { [key: string]: string }, onClose: () => void) {
         let data: IWebItem[] = [];
         this._loadOneDrive = values["LoadOneDrive"] == "true";
+        this._oversharedGroups = oversharedGroups;
         this._stopFl = false;
 
         // Clear the items
@@ -464,7 +548,9 @@ export class DLP {
     }
 
     // Searches a library for DLP conditions
-    static searchLibrary(webId: string, webUrl: string, libId: string, libTitle: string) {
+    static searchLibrary(webId: string, webUrl: string, libId: string, libTitle: string, oversharedGroups: string[]) {
+        this._oversharedGroups = oversharedGroups;
+
         // Clear the items
         this._items = [];
 
@@ -540,6 +626,7 @@ export class DLP {
                                 LastProcessedTime: result.GetDlpPolicyTip.LastProcessedTime,
                                 ListId: libId,
                                 ListTitle: libTitle,
+                                Overshared: this.isOvershared(result.RoleAssignments.results as any) ? "Yes" : "No",
                                 Path: item["FileRef"],
                                 Permissions: result.RoleAssignments.results as any,
                                 WebId: webId,

--- a/src/reports/dlp.ts
+++ b/src/reports/dlp.ts
@@ -1,4 +1,4 @@
-import { Dashboard, Documents, LoadingDialog, Modal } from "dattatable";
+import { CanvasForm, Dashboard, Documents, LoadingDialog, Modal } from "dattatable";
 import { Components, Helper, SPTypes, Types, Web } from "gd-sprest-bs";
 import { fileEarmark } from "gd-sprest-bs/build/icons/svgs/fileEarmark";
 import * as moment from "moment";
@@ -13,10 +13,13 @@ interface IDLPItem {
     FileExtension: string;
     FileName: string;
     GeneralText: string;
+    HasUniquePermissions: boolean;
+    Id: number;
     LastProcessedTime: string;
     ListId: string;
     ListTitle: string;
     Path: string;
+    Permissions: Types.SP.RoleAssignmentOData[];
     WebUrl: string;
     WebId: string;
 }
@@ -115,22 +118,28 @@ export class DLP {
                             // See if we are analyzing this file
                             if (analyzeFile) {
                                 // Create a batch request to get the dlp policy on this item
-                                list.Items(item.Id).GetDlpPolicyTip().batch(result => {
+                                list.Items(item.Id).query({
+                                    Expand: ["GetDlpPolicyTip", "RoleAssignments/Member/Users", "RoleAssignments/RoleDefinitionBindings"],
+                                    Select: ["Id", "HasUniqueRoleAssignments"]
+                                }).batch(result => {
                                     // Ensure a policy exists
-                                    if (typeof (result["GetDlpPolicyTip"]) === "undefined") {
+                                    if (result.GetDlpPolicyTip?.MatchedConditionDescriptions) {
                                         // Parse the conditions
-                                        result.MatchedConditionDescriptions.results.forEach(condition => {
+                                        result.GetDlpPolicyTip.MatchedConditionDescriptions.results.forEach(condition => {
                                             let dataItem: IDLPItem = {
-                                                AppliedActionsText: result.AppliedActionsText,
+                                                AppliedActionsText: result.GetDlpPolicyTip.AppliedActionsText,
                                                 Author: item["Author"]?.Title,
                                                 ConditionDescription: condition,
                                                 FileExtension: item["File_x0020_Type"],
                                                 FileName: item["FileLeafRef"],
-                                                GeneralText: result.GeneralText,
-                                                LastProcessedTime: result.LastProcessedTime,
+                                                GeneralText: result.GetDlpPolicyTip.GeneralText,
+                                                HasUniquePermissions: result.HasUniqueRoleAssignments,
+                                                Id: item.Id,
+                                                LastProcessedTime: result.GetDlpPolicyTip.LastProcessedTime,
                                                 ListId: lib.Id,
                                                 ListTitle: lib.Title,
                                                 Path: item["FileRef"],
+                                                Permissions: result.RoleAssignments.results as any,
                                                 WebId: webId,
                                                 WebUrl: webUrl
                                             };
@@ -199,14 +208,14 @@ export class DLP {
                 onRendering: dtProps => {
                     dtProps.columnDefs = [
                         {
-                            "targets": 5,
+                            "targets": [4, 5],
                             "orderable": false,
                             "searchable": false
                         }
                     ];
 
-                    // Order by the 1st column by default; ascending
-                    dtProps.order = [[2, "asc"]];
+                    // Order by the 2nd column by default; ascending
+                    dtProps.order = [[1, "asc"]];
 
                     // Return the properties
                     return dtProps;
@@ -217,16 +226,17 @@ export class DLP {
                         title: "List"
                     },
                     {
-                        name: "Author",
-                        title: "Created By"
-                    },
-                    {
                         name: "Path",
                         title: "File",
                         onRenderCell: (el, col, item: IDLPItem) => {
+                            // Set the order info
+                            el.setAttribute("data-order", item.FileName);
+
                             // Show the file info
                             el.innerHTML = `
                                 <b>Name: </b>${item.FileName}
+                                <br/>
+                                <b>Created By: </b>${item.Author}
                                 <br/>
                                 <b>Path: </b>${item.Path}
                             `;
@@ -244,32 +254,109 @@ export class DLP {
                         }
                     },
                     {
+                        name: "",
+                        title: "Permissions",
+                        onRenderCell: (el, col, item: IDLPItem) => {
+                            let adGroups = 0;
+                            let m365Groups = 0;
+                            let siteGroups = 0;
+                            let users = 0;
+
+                            // Parse the permissions
+                            item.Permissions.forEach(role => {
+                                // See if this is a user
+                                switch (role.Member.PrincipalType) {
+                                    case SPTypes.PrincipalTypes.User:
+                                        users++;
+                                        break;
+                                    case SPTypes.PrincipalTypes.SharePointGroup:
+                                        siteGroups++;
+                                        break;
+                                    default:
+                                        let groupId = DataSource.getGroupId(role.Member.LoginName);
+                                        groupId ? m365Groups++ : adGroups++;
+                                        break;
+                                }
+                            });
+
+                            // Output the permission information
+                            el.innerHTML = `
+                                <b>Unique Permissions: </b>${item.HasUniquePermissions ? "Yes" : "No"}
+                                <br/>
+                                <b># of Users: </b>${users}
+                                <br/>
+                                <b># of Site Groups: </b>${siteGroups}
+                                <br/>
+                                <b># of AD Groups: </b>${adGroups}
+                                <br/>
+                                <b># of M365 Groups: </b>${m365Groups}
+                                <br/>
+                            `;
+                        }
+                    },
+                    {
                         className: "text-end",
                         name: "",
                         title: "",
                         onRenderCell: (el, col, row: IDLPItem) => {
                             let btnDelete: Components.IButton = null;
 
-                            // Render the buttons
-                            let tooltips = Components.TooltipGroup({
-                                el,
-                                tooltips: [
-                                    {
-                                        content: "View Document",
-                                        btnProps: {
-                                            className: "pe-2 py-1",
-                                            iconClassName: "mx-1",
-                                            iconType: fileEarmark,
-                                            iconSize: 24,
-                                            text: "View",
-                                            type: Components.ButtonTypes.OutlinePrimary,
-                                            onClick: () => {
-                                                // View the document
-                                                window.open(Documents.isWopi(`${row.FileName}`) ? row.WebUrl + "/_layouts/15/WopiFrame.aspx?sourcedoc=" + row.Path + "&action=view" : row.Path, "_blank");
+                            // Set the tooltips
+                            let tooltips: Components.ITooltipProps[] = [
+                                {
+                                    content: "Click to view the document.",
+                                    btnProps: {
+                                        className: "pe-2 py-1",
+                                        iconClassName: "mx-1",
+                                        iconType: fileEarmark,
+                                        iconSize: 24,
+                                        text: "View",
+                                        type: Components.ButtonTypes.OutlinePrimary,
+                                        onClick: () => {
+                                            // View the document
+                                            window.open(Documents.isWopi(`${row.FileName}`) ? row.WebUrl + "/_layouts/15/WopiFrame.aspx?sourcedoc=" + row.Path + "&action=view" : row.Path, "_blank");
+                                        }
+                                    }
+                                },
+                                {
+                                    content: "Click to view the permissions for this document.",
+                                    btnProps: {
+                                        className: "pe-2 py-1",
+                                        text: "View Permissions",
+                                        type: Components.ButtonTypes.OutlinePrimary,
+                                        onClick: () => {
+                                            // View the permissions for the document
+                                            this.viewPermissions(row);
+                                        }
+                                    }
+                                }
+                            ];
+
+                            // See if the file has broken inheritance
+                            if (row.HasUniquePermissions) {
+                                // Add the option to revert the permissions
+                                tooltips.push({
+                                    content: "Click to restore permissions to inherit.",
+                                    btnProps: {
+                                        assignTo: btn => { btnDelete = btn; },
+                                        className: "pe-2 py-1",
+                                        text: "Restore",
+                                        type: Components.ButtonTypes.OutlinePrimary,
+                                        onClick: () => {
+                                            // Confirm the deletion of the group
+                                            if (confirm("Are you sure you restore the permissions to inherit?")) {
+                                                // Revert the permissions
+                                                this.revertPermissions(row);
                                             }
                                         }
                                     }
-                                ]
+                                });
+                            }
+
+                            // Render the buttons
+                            Components.TooltipGroup({
+                                el,
+                                tooltips
                             });
                         }
                     }
@@ -282,6 +369,21 @@ export class DLP {
         this._elSubNav.classList.remove("d-none");
         this._elSubNav.classList.add("my-2");
         this._elSubNav.innerHTML = `<div class="h6"></div><div></div>`;
+    }
+
+    // Reverts the item permissions
+    private static revertPermissions(item: IDLPItem) {
+        // Show a loading dialog
+        LoadingDialog.setHeader("Restoring Permissions");
+        LoadingDialog.setBody("This window will close after the item permissions are restored...");
+        LoadingDialog.show();
+
+        // Restore the permissions
+        Web(item.WebUrl, { requestDigest: DataSource.SiteContext.FormDigestValue })
+            .Lists().getById(item.ListId).Items(item.Id).resetRoleInheritance().execute(() => {
+                // Close the loading dialog
+                LoadingDialog.hide();
+            });
     }
 
     // Runs the report
@@ -418,22 +520,28 @@ export class DLP {
             },
             onItem: item => {
                 // Create a batch request to get the dlp policy on this item
-                list.Items(item.Id).GetDlpPolicyTip().batch(result => {
+                list.Items(item.Id).query({
+                    Expand: ["GetDlpPolicyTip", "RoleAssignments/Member/Users", "RoleAssignments/RoleDefinitionBindings"],
+                    Select: ["Id", "HasUniqueRoleAssignments"]
+                }).batch(result => {
                     // Ensure a policy exists
-                    if (typeof (result["GetDlpPolicyTip"]) === "undefined") {
+                    if (result.GetDlpPolicyTip?.MatchedConditionDescriptions) {
                         // Parse the conditions
-                        result.MatchedConditionDescriptions.results.forEach(condition => {
+                        result.GetDlpPolicyTip.MatchedConditionDescriptions.results.forEach(condition => {
                             let dataItem: IDLPItem = {
-                                AppliedActionsText: result.AppliedActionsText,
+                                AppliedActionsText: result.GetDlpPolicyTip.AppliedActionsText,
                                 Author: item["Author"]?.Title,
                                 ConditionDescription: condition,
                                 FileExtension: item["File_x0020_Type"],
                                 FileName: item["FileLeafRef"],
-                                GeneralText: result.GeneralText,
-                                LastProcessedTime: result.LastProcessedTime,
+                                GeneralText: result.GetDlpPolicyTip.GeneralText,
+                                HasUniquePermissions: result.HasUniqueRoleAssignments,
+                                Id: item.Id,
+                                LastProcessedTime: result.GetDlpPolicyTip.LastProcessedTime,
                                 ListId: libId,
                                 ListTitle: libTitle,
                                 Path: item["FileRef"],
+                                Permissions: result.RoleAssignments.results as any,
                                 WebId: webId,
                                 WebUrl: webUrl
                             };
@@ -468,4 +576,94 @@ export class DLP {
 
     // Stops the report
     static stop() { this._stopFl = true; }
+
+    // Views the permissions for the item
+    private static viewPermissions(item: IDLPItem) {
+        // Clear the canvas form
+        CanvasForm.clear();
+        CanvasForm.setHeader("View Permissions");
+        CanvasForm.setSize(Components.OffcanvasSize.Large2);
+        CanvasForm.setType(Components.OffcanvasTypes.End);
+
+        // Set the row data
+        let rows: {
+            GroupName?: string;
+            Member: string;
+            Permission: string;
+            Type: string;
+        }[] = [];
+
+        // Parse the permissions
+        item.Permissions.forEach(role => {
+            // Parse the role definitions
+            let roleDefinitions = [];
+            role.RoleDefinitionBindings.results.forEach(roleDef => {
+                roleDefinitions.push(`<span><b>${roleDef.Name}:</b> ${roleDef.Description}${roleDef.Hidden ? " (Hidden)" : ""}</span>`);
+            });
+
+            // See if this is a user
+            switch (role.Member.PrincipalType) {
+                case SPTypes.PrincipalTypes.User:
+                    rows.push({
+                        Member: role.Member.Title || role.Member.LoginName,
+                        Type: "User",
+                        Permission: roleDefinitions.join('<br/>')
+                    });
+                    break;
+                case SPTypes.PrincipalTypes.SharePointGroup:
+                    // Parse the members
+                    (role.Member["Users"] ? role.Member["Users"].results : []).forEach(user => {
+                        rows.push({
+                            Member: user.Email || user.LoginName,
+                            Type: "Site Group",
+                            GroupName: role.Member.Title,
+                            Permission: roleDefinitions.join('<br/>')
+                        });
+                    });
+                    break;
+                default:
+                    let groupId = DataSource.getGroupId(role.Member.LoginName);
+                    rows.push({
+                        Member: role.Member.Title,
+                        Type: groupId ? "M365 Group" : "AD Group",
+                        GroupName: role.Member.Title,
+                        Permission: roleDefinitions.join('<br/>')
+                    });
+                    break;
+            }
+        });
+
+        // Render the permissions
+        new Dashboard({
+            el: CanvasForm.BodyElement,
+            navigation: {
+                showFilter: false,
+                title: item.FileName
+            },
+            table: {
+                rows,
+                columns: [
+                    {
+                        name: "Member",
+                        title: "Member"
+                    },
+                    {
+                        name: "Type",
+                        title: "Type",
+                    },
+                    {
+                        name: "GroupName",
+                        title: "Group Name"
+                    },
+                    {
+                        name: "Permission",
+                        title: "Permission"
+                    }
+                ]
+            }
+        });
+
+        // Show the form
+        CanvasForm.show();
+    }
 }

--- a/src/reports/dlp.ts
+++ b/src/reports/dlp.ts
@@ -1,7 +1,6 @@
 import { CanvasForm, Dashboard, Documents, LoadingDialog, Modal } from "dattatable";
-import { Components, Helper, SPTypes, Types, Web } from "gd-sprest-bs";
+import { Components, ContextInfo, Helper, SPTypes, Types, Web } from "gd-sprest-bs";
 import { fileEarmark } from "gd-sprest-bs/build/icons/svgs/fileEarmark";
-import * as moment from "moment";
 import { DataSource } from "../ds";
 import Strings from "../strings";
 import { ExportCSV } from "./exportCSV";
@@ -23,6 +22,13 @@ interface IDLPItem {
     Permissions: Types.SP.RoleAssignmentOData[];
     WebUrl: string;
     WebId: string;
+}
+
+interface IDLPPermission {
+    GroupName?: string;
+    Member: string;
+    Permission: string;
+    Type: string;
 }
 
 interface IWebItem {
@@ -673,12 +679,7 @@ export class DLP {
         CanvasForm.setType(Components.OffcanvasTypes.End);
 
         // Set the row data
-        let rows: {
-            GroupName?: string;
-            Member: string;
-            Permission: string;
-            Type: string;
-        }[] = [];
+        let rows: IDLPPermission[] = [];
 
         // Parse the permissions
         item.Permissions.forEach(role => {
@@ -729,6 +730,15 @@ export class DLP {
             },
             table: {
                 rows,
+                onRendering(dtProps) {
+                    dtProps.columnDefs = [
+                        {
+                            "targets": [4],
+                            "orderable": false,
+                            "searchable": false
+                        }
+                    ];
+                },
                 columns: [
                     {
                         name: "Member",
@@ -745,6 +755,48 @@ export class DLP {
                     {
                         name: "Permission",
                         title: "Permission"
+                    },
+                    {
+                        name: "",
+                        title: "Actions",
+                        onRenderCell: (el, col, row: IDLPPermission) => {
+                            let tooltips: Components.ITooltipProps[] = [];
+
+                            // See if this is a site group
+                            if (row.Type === "Site Group") {
+                                tooltips.push({
+                                    content: "Click to view the site group.",
+                                    btnProps: {
+                                        text: "View Group",
+                                        type: Components.ButtonTypes.OutlinePrimary,
+                                        onClick: () => {
+                                            document.open(`${item.WebUrl}/${ContextInfo.layoutsUrl}/people.aspx?MembershipGroupId=${item.Id}`, "_blank");
+                                        }
+                                    }
+                                });
+                            }
+
+                            // See if this is an ad group or user
+                            if (row.Type === "AD Group" || row.Type === "User") {
+                                tooltips.push({
+                                    content: "Click to view the user.",
+                                    btnProps: {
+                                        text: row.Type === "AD Group" ? "View Group" : "View User",
+                                        type: Components.ButtonTypes.OutlinePrimary,
+                                        onClick: () => {
+                                            document.open(`${item.WebUrl}/${ContextInfo.layoutsUrl}/userdisp.aspx?ID=${item.Id}`, "_blank");
+                                        }
+                                    }
+                                });
+                            }
+
+                            // Render the actions
+                            Components.TooltipGroup({
+                                el,
+                                isVertical: true,
+                                tooltips
+                            });
+                        }
                     }
                 ]
             }

--- a/src/reports/dlp.ts
+++ b/src/reports/dlp.ts
@@ -2,6 +2,7 @@ import { CanvasForm, Dashboard, Documents, LoadingDialog, Modal } from "dattatab
 import { Components, ContextInfo, Helper, SPTypes, Types, Web } from "gd-sprest-bs";
 import { fileEarmark } from "gd-sprest-bs/build/icons/svgs/fileEarmark";
 import { DataSource } from "../ds";
+import { M365Groups } from "../m365Groups";
 import Strings from "../strings";
 import { ExportCSV } from "./exportCSV";
 
@@ -362,7 +363,7 @@ export class DLP {
                                         siteGroups++;
                                         break;
                                     default:
-                                        let groupId = DataSource.getGroupId(role.Member.LoginName);
+                                        let groupId = M365Groups.getGroupId(role.Member.LoginName);
                                         groupId ? m365Groups++ : adGroups++;
                                         break;
                                 }
@@ -710,7 +711,7 @@ export class DLP {
                     });
                     break;
                 default:
-                    let groupId = DataSource.getGroupId(role.Member.LoginName);
+                    let groupId = M365Groups.getGroupId(role.Member.LoginName);
                     rows.push({
                         Member: role.Member.Title,
                         Type: groupId ? "M365 Group" : "AD Group",
@@ -770,7 +771,7 @@ export class DLP {
                                         text: "View Group",
                                         type: Components.ButtonTypes.OutlinePrimary,
                                         onClick: () => {
-                                            document.open(`${item.WebUrl}/${ContextInfo.layoutsUrl}/people.aspx?MembershipGroupId=${item.Id}`, "_blank");
+                                            window.open(`${item.WebUrl}/${ContextInfo.layoutsUrl}/people.aspx?MembershipGroupId=${item.Id}`, "_blank");
                                         }
                                     }
                                 });
@@ -784,7 +785,7 @@ export class DLP {
                                         text: row.Type === "AD Group" ? "View Group" : "View User",
                                         type: Components.ButtonTypes.OutlinePrimary,
                                         onClick: () => {
-                                            document.open(`${item.WebUrl}/${ContextInfo.layoutsUrl}/userdisp.aspx?ID=${item.Id}`, "_blank");
+                                            window.open(`${item.WebUrl}/${ContextInfo.layoutsUrl}/userdisp.aspx?ID=${item.Id}`, "_blank");
                                         }
                                     }
                                 });

--- a/src/reports/dlp.ts
+++ b/src/reports/dlp.ts
@@ -261,7 +261,7 @@ export class DLP {
 
         // Set the content
         CanvasForm.setBody(`
-            <p>The file will break inheritance and remove the groups that are flagging this file as overshared. Click on 'Confirm' below to proceed with this action.</p>
+            <p>This action will create unique permissions for the file and remove the large audience group(s) that are flagging the file as overshared. If access to the file is currently granted through a SharePoint group—such as the Visitors group—that group will be removed from the file's permissions. In these cases, it is recommended to review the file's permissions afterward to determine whether any users removed through the Visitors group need to be restored.</p>
             <div class="d-flex justify-content-end"></div>
         `);
 
@@ -550,17 +550,22 @@ export class DLP {
                                         onClick: () => {
                                             // Remove the overshared groups from the permissions
                                             this.removeOversharedGroups(row, permissions => {
-                                                // Update the permissions for this item
-                                                row.Permissions = permissions;
+                                                // Parse the items
+                                                this._items.forEach(item => {
+                                                    if (item.Id == row.Id) {
+                                                        // Update the permissions
+                                                        item.Permissions = permissions;
 
-                                                // Update the overshared status
-                                                row.Overshared = this.isOvershared(permissions) ? "Yes" : "No";
+                                                        // Update the flag
+                                                        item.Overshared = this.isOvershared(permissions) ? "Yes" : "No";
 
-                                                // Set the flag if we are no longer oversharing
-                                                row.HasUniquePermissions = row.Overshared === "Yes" ? row.HasUniquePermissions : true;
+                                                        // Set the flag if we are no longer oversharing
+                                                        item.HasUniquePermissions = item.Overshared === "Yes" ? item.HasUniquePermissions : true;
+                                                    }
+                                                });
 
-                                                // Update this row
-                                                this._dashboard.updateRow(rowIdx, row);
+                                                // Update the dashboard
+                                                this._dashboard.refresh(this._items);
                                             });
                                         }
                                     }

--- a/src/reports/permissions.ts
+++ b/src/reports/permissions.ts
@@ -1,6 +1,7 @@
 import { Dashboard, LoadingDialog, Modal } from "dattatable";
-import { Components, ContextInfo, DirectorySession, Helper, SPTypes, Types, Web } from "gd-sprest-bs";
+import { Components, ContextInfo, Helper, SPTypes, Types, Web } from "gd-sprest-bs";
 import { DataSource } from "../ds";
+import { IM365Result, M365Groups } from "../m365Groups";
 import { ExportCSV } from "./exportCSV";
 
 interface IPermissionItem {
@@ -36,8 +37,7 @@ export class Permissions {
     private static _dashboard: Dashboard = null;
     private static _elDashboard: HTMLElement = null;
     private static _elSubNav: HTMLElement = null;
-    private static _groupIds: { [key: string]: Types.SP.Directory.GroupOData } = null;
-    private static _groupIdErrors: string[] = null;
+    private static _groups: IM365Result = null;
     private static _items: IPermissionItem[] = null;
     private static _loadOneDrive: boolean = false;
     private static _roleMapper: { [key: string]: Types.SP.User } = null;
@@ -47,62 +47,16 @@ export class Permissions {
     private static analyzeGroupIds(webUrl: string, groupIds: string[]): PromiseLike<void> {
         // Return a promise
         return new Promise(resolve => {
-            // Try to get the groups
             let counter = 0;
-            Helper.Executor(groupIds, groupId => {
+
+            // Load the group information
+            M365Groups.getGroupInfo(groupIds, group => {
                 // Update the dialog
                 this._elSubNav.children[1].innerHTML = `Trying to get M365 Group information: ${++counter} of ${groupIds.length}`;
+            }).then((groups) => {
+                // Save the groups
+                this._groups = groups;
 
-                // Return a promise
-                return new Promise(resolve => {
-                    // Skip this, if we have already queried for this group
-                    if (this._groupIds[groupId] || this._groupIdErrors.indexOf(groupId) >= 0) { resolve(null); return; }
-
-                    // Get the group information
-                    let ds = DirectorySession().group(groupId);
-                    ds.query({
-                        Select: ["calendarUrl", "displayName", "id", "isPublic", "mail"]
-                    }).execute(group => {
-                        // Save the group information
-                        this._groupIds[groupId] = group;
-
-                        // Get the group members
-                        ds.members().query({
-                            GetAllItems: true,
-                            Top: 5000,
-                            Select: ["principalName", "id", "displayName", "mail"]
-                        }).execute(members => {
-                            // Add the group information to the mapper
-                            this._groupIds[groupId].members = members as any;
-                        }, () => {
-                            // Try the next group
-                            resolve(null);
-                        });
-
-                        // Get the group owners
-                        ds.owners().query({
-                            GetAllItems: true,
-                            Top: 5000,
-                            Select: ["principalName", "id", "displayName", "mail"]
-                        }).execute(owners => {
-                            // Add the group information to the mapper
-                            this._groupIds[groupId].owners = owners as any;
-
-                            // Try the next group
-                            resolve(null);
-                        }, () => {
-                            // Try the next group
-                            resolve(null);
-                        }, true);
-                    }, () => {
-                        // Append the error
-                        this._groupIdErrors.push(groupId);
-
-                        // Try the next group
-                        resolve(null);
-                    });
-                });
-            }).then(() => {
                 // Update the dialog
                 this._elSubNav.children[1].innerHTML = `Updating the role assignments with the M365 Group information`;
 
@@ -132,8 +86,8 @@ export class Permissions {
                         // See if this is a group
                         if (member.PrincipalType == SPTypes.PrincipalTypes.SecurityGroup) {
                             // Get the group id
-                            let groupId = DataSource.getGroupId(member.LoginName);
-                            let group = this._groupIds[groupId];
+                            let groupId = M365Groups.getGroupId(member.LoginName);
+                            let group = groups.groups[groupId];
                             if (group) {
                                 // See if this is a reference to the owner's group
                                 if (member.LoginName.endsWith("_o")) {
@@ -276,7 +230,7 @@ export class Permissions {
                     };
                 } else {
                     // See if this is a M365 group
-                    let groupId = DataSource.getGroupId(role.Member.LoginName);
+                    let groupId = M365Groups.getGroupId(role.Member.LoginName);
 
                     // Add the role information
                     item = {
@@ -373,7 +327,7 @@ export class Permissions {
             // See if this is a M365 Group
             if (user.PrincipalType == SPTypes.PrincipalTypes.SecurityGroup) {
                 // Get the group id
-                let groupId = DataSource.getGroupId(user.LoginName);
+                let groupId = M365Groups.getGroupId(user.LoginName);
                 if (groupId) {
                     // Add the group id
                     item.GroupIds.push(groupId);
@@ -399,8 +353,7 @@ export class Permissions {
 
         // Parse the errors
         let rows = [];
-        for (let i = 0; i < this._groupIdErrors.length; i++) {
-            let groupId = this._groupIdErrors[i];
+        for (let groupId of Object.keys(this._groups.error)) {
             let mapper = this._roleMapper[groupId];
 
             // Add the row
@@ -566,7 +519,7 @@ export class Permissions {
                                     }
 
                                     // Exclude M365 groups
-                                    return DataSource.getGroupId(value.LoginName) ? false : true;
+                                    return M365Groups.getGroupId(value.LoginName) ? false : true;
                                 });
 
                                 // Set the value
@@ -702,8 +655,7 @@ export class Permissions {
         LoadingDialog.show();
 
         // Clear the items
-        this._groupIds = {};
-        this._groupIdErrors = [];
+        this._groups = null;
         this._items = [];
         this._roleMapper = {};
 
@@ -760,7 +712,7 @@ export class Permissions {
             this._elSubNav.classList.add("d-none");
 
             // See if no errors exist
-            if (this._groupIdErrors.length == 0) {
+            if (Object.keys(this._groups.error).length == 0) {
                 // Get the error button
                 let elNav = this._elDashboard.querySelector("#navigation .navbar-nav");
 

--- a/src/reports/searchUsers.ts
+++ b/src/reports/searchUsers.ts
@@ -1,6 +1,7 @@
 import { Dashboard, LoadingDialog } from "dattatable";
-import { Components, ContextInfo, DirectorySession, Helper, SPTypes, Types, Web } from "gd-sprest-bs";
+import { Components, ContextInfo, Helper, SPTypes, Types, Web } from "gd-sprest-bs";
 import { DataSource } from "../ds";
+import { M365Groups } from "../m365Groups";
 import { ExportCSV } from "./exportCSV";
 
 interface ISearchItem {
@@ -55,7 +56,7 @@ export class SearchUsers {
                     // See if this role is the user
                     if (role.Member.LoginName == userInfo.Name) {
                         // Add the user information
-                        let userItem = {
+                        let userItem: ISearchItem = {
                             WebUrl: web.Url,
                             WebTitle: web.Title,
                             Id: userInfo.Id,
@@ -80,7 +81,7 @@ export class SearchUsers {
                             // Parse the users
                             Helper.Executor(users.results, user => {
                                 // Get the group id
-                                let groupId = DataSource.getGroupId(user.LoginName);
+                                let groupId = M365Groups.getGroupId(user.LoginName);
                                 if (groupId) {
                                     // See if this is an owners group
                                     if (user.LoginName.endsWith("_o")) {
@@ -94,7 +95,7 @@ export class SearchUsers {
                         });
                     } else {
                         // Get the group id
-                        let groupId = DataSource.getGroupId(role.Member.LoginName);
+                        let groupId = M365Groups.getGroupId(role.Member.LoginName);
                         if (groupId) {
                             // See if this is an owners group
                             if (role.Member.LoginName.endsWith("_o")) {
@@ -111,99 +112,75 @@ export class SearchUsers {
                 });
             }).then(() => {
                 // Get the group ids
+                let counter = 0;
                 let groupIds = [];
                 for (let groupId in groups) { groupIds.push(groupId); }
 
-                // Parse the group ids
-                let ctrGroupIds = 0;
-                Helper.Executor(groupIds, groupId => {
+                // Get the group information
+                M365Groups.getGroupInfo(groupIds, (group, groupId) => {
                     // Update the dialog
-                    this._elSubNav.children[1].innerHTML = `Getting M365 group info: ${++ctrGroupIds} of ${groupIds.length}...`;
+                    this._elSubNav.children[1].innerHTML = `Getting M365 group info: ${++counter} of ${groupIds.length}...`;
 
-                    // Return a promise
-                    return new Promise(resolve => {
-                        let groupInfo = groupId.split('_');
-                        let groupName: string = null;
-                        let groupUrl: string = null;
-                        let isOwner = groupInfo.length > 1;
+                    // Do nothing if the group didn't load
+                    if (group == null) { return; }
 
-                        // Get the group information
-                        let ds = DirectorySession().group(groupInfo[0]);
-                        ds.query({
-                            Select: ["calendarUrl", "displayName", "id"]
-                        }).batch(group => {
-                            // Set the group name
-                            groupName = group.displayName;
-                            groupUrl = group.calendarUrl.replace("calendar/group", "groups") + "/members";
-                        });
+                    // Get the group information
+                    let groupInfo = groupId.split('_');
+                    let isOwner = groupInfo.length > 1;
+                    let role = groups[groupId];
+                    let users = groupInfo.length > 1 ? group.owners : group.members;
 
-                        // Get the owners/members for the group
-                        (isOwner ? ds.owners() : ds.members()).query({
-                            GetAllItems: true,
-                            Top: 5000,
-                            Select: ["principalName", "id", "displayName", "mail"]
-                        }).batch(users => {
-                            let role = groups[groupId];
+                    // Parse the users
+                    for (let i = 0; i < users?.results.length; i++) {
+                        let user = users.results[i];
 
-                            // Parse the users
-                            for (let i = 0; i < users?.results.length; i++) {
-                                let user = users.results[i];
-
-                                // See if we are searching by string
-                                if (typeof (search) === "string") {
-                                    // See this is the user
-                                    if (user.displayName.toLowerCase().indexOf(search.toString()) >= 0) {
-                                        // Add the user information
-                                        let userItem = {
-                                            WebUrl: web.Url,
-                                            WebTitle: web.Title,
-                                            Id: user.id,
-                                            LoginName: user.mail,
-                                            Name: user.displayName,
-                                            Email: user.mail,
-                                            Group: role.Member.Title,
-                                            GroupId: role.Member.Id,
-                                            GroupInfo: `${groupName} M365 Group ${isOwner ? "owner" : "member"}`,
-                                            IsM365Group: true,
-                                            M365GroupUrl: groupUrl,
-                                            Role: role.RoleDefinitionBindings.results[0].Name,
-                                            RoleInfo: role.RoleDefinitionBindings.results[0].Description || ""
-                                        };
-                                        this._items.push(userItem);
-                                        this._dashboard.Datatable.addRow(userItem);
-                                    }
-                                }
-                                // Else, compare the email
-                                else if (user.mail == userInfo.EMail) {
-                                    // Add the user information
-                                    let userItem = {
-                                        WebUrl: web.Url,
-                                        WebTitle: web.Title,
-                                        Id: user.id,
-                                        LoginName: user.mail,
-                                        Name: user.displayName,
-                                        Email: user.mail,
-                                        Group: role.Member.Title,
-                                        GroupId: role.Member.Id,
-                                        GroupInfo: `${groupName} M365 Group ${isOwner ? "owner" : "member"}`,
-                                        IsM365Group: true,
-                                        M365GroupUrl: groupUrl,
-                                        Role: role.RoleDefinitionBindings.results[0].Name,
-                                        RoleInfo: role.RoleDefinitionBindings.results[0].Description || ""
-                                    };
-                                    this._items.push(userItem);
-                                    this._dashboard.Datatable.addRow(userItem);
-                                }
+                        // See if we are searching by string
+                        if (typeof (search) === "string") {
+                            // See this is the user
+                            if (user.displayName.toLowerCase().indexOf(search.toString()) >= 0) {
+                                // Add the user information
+                                let userItem = {
+                                    WebUrl: web.Url,
+                                    WebTitle: web.Title,
+                                    Id: user.id,
+                                    LoginName: user.mail,
+                                    Name: user.displayName,
+                                    Email: user.mail,
+                                    Group: role.Member.Title,
+                                    GroupId: role.Member.Id,
+                                    GroupInfo: `${group.displayName} M365 Group ${isOwner ? "owner" : "member"}`,
+                                    IsM365Group: true,
+                                    M365GroupUrl: M365Groups.getGroupUrl(group),
+                                    Role: role.RoleDefinitionBindings.results[0].Name,
+                                    RoleInfo: role.RoleDefinitionBindings.results[0].Description || ""
+                                };
+                                this._items.push(userItem);
+                                this._dashboard.Datatable.addRow(userItem);
                             }
-                        });
-
-                        // Execute the request
-                        ds.execute(() => {
-                            // Try the next group
-                            resolve(null);
-                        });
-                    });
-                }).then(resolve);
+                        }
+                        // Else, compare the email
+                        else if (user.mail == userInfo.EMail) {
+                            // Add the user information
+                            let userItem = {
+                                WebUrl: web.Url,
+                                WebTitle: web.Title,
+                                Id: user.id,
+                                LoginName: user.mail,
+                                Name: user.displayName,
+                                Email: user.mail,
+                                Group: role.Member.Title,
+                                GroupId: role.Member.Id,
+                                GroupInfo: `${group.displayName} M365 Group ${isOwner ? "owner" : "member"}`,
+                                IsM365Group: true,
+                                M365GroupUrl: M365Groups.getGroupUrl(group),
+                                Role: role.RoleDefinitionBindings.results[0].Name,
+                                RoleInfo: role.RoleDefinitionBindings.results[0].Description || ""
+                            };
+                            this._items.push(userItem);
+                            this._dashboard.Datatable.addRow(userItem);
+                        }
+                    }
+                }).then(() => { resolve(); });
             });
         });
     }

--- a/src/reports/sensitivityLabels.ts
+++ b/src/reports/sensitivityLabels.ts
@@ -810,7 +810,7 @@ export class SensitivityLabels {
                     label: "Select Sensitivity Label:",
                     description: "This will set any file that isn't currently labelled.",
                     errorMessage: "A sensitivity label is required.",
-                    items: DataSource.SiteSensitivityLabelItems,
+                    items: DataSource.SensitivityLabelItems,
                     type: Components.FormControlTypes.Dropdown,
                     required: true,
                     value: defaultLabel,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -8,9 +8,18 @@
     }
 }
 
+/** Show the canvas form over the modal */
+/** Set the height to be under the top bar */
+#core-canvas > .offcanvas {
+    height: 96vh;
+    margin-top: 50px;
+    z-index: 1100;
+}
+
 /** Ensure the modal is under the top bar */
 #core-modal {
     .modal:has(> .modal-fullscreen) {
+        height: 96vh;
         margin-top: 50px;
     }
 }

--- a/src/tabs/lists.ts
+++ b/src/tabs/lists.ts
@@ -549,7 +549,7 @@ export class ListsTab {
                                 switch (selectedReport) {
                                     case ReportTypes.DLP:
                                         // Run the DLP report for this library
-                                        DLP.searchLibrary(item.WebId, item.WebUrl, item.ListId, item.ListName);
+                                        DLP.searchLibrary(item.WebId, item.WebUrl, item.ListId, item.ListName, this._appProps.reportProps.dlpGroups);
                                         break;
                                     case ReportTypes.SearchEEEU:
                                         // Run the EEEU report for this library

--- a/src/tabs/reports.ts
+++ b/src/tabs/reports.ts
@@ -7,6 +7,7 @@ import { ISearchProps } from "./searchProp";
 // Report Properties
 export interface IReportProps {
     dlpFileExt?: string;
+    dlpGroups?: string[];
     docRententionYears?: string;
     docSearchFileExt?: string;
     docSearchKeywords?: string;
@@ -277,7 +278,7 @@ export class ReportsTab {
                 // Run the report
                 switch (this._selectedReport) {
                     case ReportTypes.DLP:
-                        Reports.DLP.run(this._el, this._auditOnly, formValues, () => {
+                        Reports.DLP.run(this._el, this._auditOnly, this._appProps.reportProps.dlpGroups, formValues, () => {
                             // Render this component
                             this.render(this._selectedReport);
                         });


### PR DESCRIPTION
Added the ability to flag a dlp file as "overshared" based on M365/AD groups permissioned by the document. Implemented a secure action button to remove the AD/M365 groups from the permissions to fix the issue.