### PR TITLE
Hide Sensitivity Label in Lists/Libraries Tab

### DIFF
--- a/spfx/src/webparts/siteAdmin/SiteAdminWebPart.ts
+++ b/spfx/src/webparts/siteAdmin/SiteAdminWebPart.ts
@@ -608,7 +608,7 @@ export default class SiteAdminWebPart extends BaseClientSideWebPart<ISiteAdminWe
               groupName: "Sensitivity Labels",
               groupFields: [
                 PropertyPaneToggle("DisableSensitivityLabelOverride", {
-                  label: "Disable Sensivitity Label Override:",
+                  label: "Disable Sensitivity Label Override:",
                   checked: this.properties.DisableSensitivityLabelOverride,
                   onText: "The admins will only be allowed to apply sensitivity labels to files that haven't been labeled.",
                   offText: "The admins will be allowed to attempt to override sensitivity labels."
@@ -816,7 +816,7 @@ export default class SiteAdminWebPart extends BaseClientSideWebPart<ISiteAdminWe
                   offText: "The search users report will be visible."
                 }),
                 PropertyPaneToggle("HideReportSensitivityLabels", {
-                  label: "Sensivitity Labels Override:",
+                  label: "Sensitivity Labels:",
                   checked: this.properties.HideReportSensitivityLabels,
                   onText: "The sensitivity labels report will be hidden.",
                   offText: "The sensitivity labels report will be visible."

--- a/src/reports/bulkLabel.ts
+++ b/src/reports/bulkLabel.ts
@@ -815,7 +815,7 @@ export class BulkLabel {
         this._dashboard = new Dashboard({
             el: Modal.BodyElement,
             navigation: {
-                title: "Senstivity Labels",
+                title: "Sensitivity Labels",
                 showFilter: false
             },
             table: {
@@ -867,7 +867,7 @@ export class BulkLabel {
                         type: Components.ButtonTypes.OutlinePrimary,
                         onClick: () => {
                             // Export the CSV
-                            new ExportCSV("senstivity_labels.csv", CSVSensitivityLabelResponseFields, this._items);
+                            new ExportCSV("sensitivity_labels.csv", CSVSensitivityLabelResponseFields, this._items);
                         }
                     }
                 },

--- a/src/tabs/lists.ts
+++ b/src/tabs/lists.ts
@@ -198,33 +198,36 @@ export class ListsTab {
 
         // See if this is a drive
         if (isLibrary && item.DriveId) {
-            // Add the bulk label option
-            tooltips.add({
-                content: "Click to see sensitivity label options for this library.",
-                btnProps: {
-                    text: "Sensitivity Labels",
-                    type: Components.ButtonTypes.OutlinePrimary,
-                    onClick: () => {
-                        // Show a loading dialog
-                        LoadingDialog.setHeader("Loading Folders");
-                        LoadingDialog.setBody("Loading the root folders of this library...");
-                        LoadingDialog.show();
+            // See if we are displaying this option
+            if (typeof (this._appProps.hideReports.sensitivityLabels) === "undefined" || this._appProps.hideReports.sensitivityLabels != true) {
+                // Add the bulk label option
+                tooltips.add({
+                    content: "Click to see sensitivity label options for this library.",
+                    btnProps: {
+                        text: "Sensitivity Labels",
+                        type: Components.ButtonTypes.OutlinePrimary,
+                        onClick: () => {
+                            // Show a loading dialog
+                            LoadingDialog.setHeader("Loading Folders");
+                            LoadingDialog.setBody("Loading the root folders of this library...");
+                            LoadingDialog.show();
 
-                        // Load the folders for this list
-                        DataSource.loadFolders(item.WebId, item.DriveId).then(folders => {
-                            // Show the senstivity label form
-                            BulkLabel.showLibraryForm(item.WebId, item.WebUrl, item.ListName, item.DriveId, item.DefaultSensitivityLabel, folders, this._appProps.disableSensitivityLabelOverride, this._appProps.reportProps.sensitivityLabelFileExt, labelId => {
-                                // Update the default sensitivity label for this library
-                                item.DefaultSensitivityLabel = DataSource.getSensitivityLabel(labelId);
-                                this._dt.updateCell(rowIdx, 2, item);
+                            // Load the folders for this list
+                            DataSource.loadFolders(item.WebId, item.DriveId).then(folders => {
+                                // Show the sensitivity label form
+                                BulkLabel.showLibraryForm(item.WebId, item.WebUrl, item.ListName, item.DriveId, item.DefaultSensitivityLabel, folders, this._appProps.disableSensitivityLabelOverride, this._appProps.reportProps.sensitivityLabelFileExt, labelId => {
+                                    // Update the default sensitivity label for this library
+                                    item.DefaultSensitivityLabel = DataSource.getSensitivityLabel(labelId);
+                                    this._dt.updateCell(rowIdx, 2, item);
+                                });
+
+                                // Hide the dialog
+                                LoadingDialog.hide();
                             });
-
-                            // Hide the dialog
-                            LoadingDialog.hide();
-                        });
+                        }
                     }
-                }
-            });
+                });
+            }
         }
 
         // Add the reports tooltip
@@ -425,6 +428,7 @@ export class ListsTab {
 
         // Sensitivity Labels
         if (isLibrary && item.DriveId) {
+            // See if we are displaying this option
             if (typeof (this._appProps.hideReports.sensitivityLabels) === "undefined" || this._appProps.hideReports.sensitivityLabels != true) {
                 items.push({
                     text: "Sensitivity Labels",


### PR DESCRIPTION
Fixed label. Added the reports button setting to show/hide the sensitivity label button for lists/library tab.